### PR TITLE
fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Install
 ```shell
-npm install btcpayserver/node-btcpay
+npm i btcpay
 ```
 
 ## Private key generation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "btcpay",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btcpay",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A nodejs client implementation for BTCPay",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Installation instructions currently point the user at the github repository. This PR fixes that by pointing the installation at npm.