### PR TITLE
get_rates fix error in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const client = new btcpay.BTCPayClient(<BCTPAYURL>, keypair, {merchant: <MERCHAN
 ### Get rates
 Fetches current rates from BitcoinAverage (using your BTCPayServer)
 ```js
-client.get_rates('BTC_USD', <STOREID>)
+client.get_rates(['BTC_USD'], <STOREID>)
   .then(rates => console.log(rates))
   .catch(err => console.log(err))
 ```


### PR DESCRIPTION
the `get_rates` example fails, because it needs an array of strings instead of a single string as an argument, as stated in the typescript definition:

``` typescript
public async get_rates(
    currencyPairs: string[],
    storeID: string,
  ): Promise<Rate[]> {
    return this.signed_get_request('/rates', {
      currencyPairs: currencyPairs.join(','),
      storeID,
    });
  }
```

If executed in this way, the function returns the correct value