### PR TITLE
Match Create Invoice args to BTCPayServer source code

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -2,7 +2,11 @@ import * as elliptic from 'elliptic';
 import * as qs from 'querystring';
 import * as rp from 'request-promise';
 import * as _ from 'underscore';
-import { GetInvoicesArgs, PairClientResponse } from '../models/client';
+import {
+  CreateInvoiceArgs,
+  GetInvoicesArgs,
+  PairClientResponse,
+} from '../models/client';
 import { Cryptography as crypto } from './cryptography';
 import { Invoice } from '../models/invoice';
 import { Rate } from '../models/rate';
@@ -62,7 +66,7 @@ export class BTCPayClient {
   }
 
   public async create_invoice(
-    payload: { currency: string; price: string | number },
+    payload: CreateInvoiceArgs,
     token?: any,
   ): Promise<Invoice> {
     const re = new RegExp('^[A-Z]{3}$');

--- a/src/models/client.ts
+++ b/src/models/client.ts
@@ -11,3 +11,39 @@ export interface GetInvoicesArgs {
   limit?: number;
   offset?: number;
 }
+
+export interface CreateInvoiceArgs {
+  currency: string;
+  price: number;
+  orderId?: string | number;
+  expirationTime?: string;
+  itemDesc?: string;
+  itemCode?: string;
+  posData?: string;
+  status?: string;
+  redirectUrl?: string;
+  transactionSpeed?: 'low' | 'low-medium' | 'medium' | 'high';
+  physical?: boolean;
+  supportedTransactionCurrencies?: {
+    [index: string]: {
+      enabled: boolean;
+    };
+  };
+  refundable?: boolean;
+  taxIncluded?: number;
+  token?: string;
+  redirectAutomatically?: boolean;
+  notificationEmail?: string;
+  notificationURL?: string;
+  extendedNotifications?: boolean;
+  fullNotifications?: boolean;
+  buyerEmail?: string;
+  buyerPhone?: string;
+  buyerCountry?: string;
+  buyerZip?: string;
+  buyerState?: string;
+  buyerCity?: string;
+  buyerAddress2?: string;
+  buyerAddress1?: string;
+  buyerName?: string;
+}


### PR DESCRIPTION
Fixes #28 

Got the types from here:

https://github.com/btcpayserver/btcpayserver/blob/6407e15187d1e3216c55ab63eb6237064c21c85b/BTCPayServer/Models/CreateInvoiceRequest.cs

Also had to dig around here too:

https://github.com/MetacoSA/NBitpayClient/tree/9a61ff948270cca7fdc0b6cdeaa3c60a6546f2de/NBitpayClient

@NicolasDorier Let me know if these are wrong?