### PR TITLE
Narrow set for Invoice.status type

### DIFF
--- a/src/models/invoice.ts
+++ b/src/models/invoice.ts
@@ -1,7 +1,7 @@
 export interface Invoice {
   url: string;
   posData: string | null;
-  status: string;
+  status: 'new' | 'paid' | 'confirmed' | 'complete' | 'expired' | 'invalid';
   btcPrice: string;
   btcDue: string;
   cryptoInfo: Array<{


### PR DESCRIPTION
As seen on https://bitpay.com/docs/invoice-states, the `Invoice.status` type can be stricter. It can only be one of six string literals: `'new' | 'paid' | 'confirmed' | 'complete' | 'expired' | 'invalid'`. This pull request makes that change.